### PR TITLE
Added support for virion v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "inxomnyaa/apibossbar",
+  "description": "A simple virion API for Minecraft Bossbars for PocketMine-MP",
+  "type": "library",
+  "license": "GPL-3.0-or-later",
+  "autoload": {
+    "classmap": ["src"]
+  },
+  "require": {
+    "pocketmine/pocketmine-mp": "^5.0.0"
+  },
+  "extra": {
+    "virion":{
+      "spec": "3.0",
+      "namespace-root": "xenialdan\\apibossbar"
+    }
+  }
+}


### PR DESCRIPTION
Hi! After merging this pull request, your users may use Virion 3.0 in their plugins by using `vcs` dependencies in their composer.json, but you could make their lives easier by completing these steps:

1. Tag each release with the `git tag` command or the [GitHub web UI](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
2. Submit your package on Packagist: https://packagist.org/packages/submit

Please follow these steps every time you release a new stable version so that user plugins can get their dependencies updated automatically upon the next build.