### PR TITLE
BossBarColor Update

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -1,4 +1,4 @@
---- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/thebigsmileXD/apibossbar
+--- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/Terpz710/apibossbar
 projects:
   apibossbar:
     type: library

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Set the title and/or subtitle
 $bar->setTitle(string $title = "");
 $bar->setSubTitle(string $subTitle = "");
 ```
+Set the color
+```php
+// Available Colors:
+// RED, PINK, BLUE, GREEN, YELLOW, PURPLE, REBECCA_PURPLE and WHITE
+$bar->setColor(BarColor::RED);
+```
 Set the fill percentage
 ```php
 // Half-filled

--- a/src/xenialdan/apibossbar/BarColor.php
+++ b/src/xenialdan/apibossbar/BarColor.php
@@ -15,16 +15,16 @@ class BarColor
     const REBECCA_PURPLE = BossBarColor::REBECCA_PURPLE;
     const WHITE = BossBarColor::WHITE;
 
-    /** @var int[] */
-    public static array $colors = [
-        self::PINK,
-        self::BLUE,
-        self::RED,
-        self::GREEN,
-        self::YELLOW,
-        self::PURPLE,
-        self::REBECCA_PURPLE,
-        self::WHITE,
+    /** @var string[] */
+    public static array $colorNames = [
+        self::PINK => "pink",
+        self::BLUE => "blue",
+        self::RED => "red",
+        self::GREEN => "green",
+        self::YELLOW => "yellow",
+        self::PURPLE => "purple",
+        self::REBECCA_PURPLE => "rebecca_purple",
+        self::WHITE => "white",
     ];
 
     /**
@@ -34,6 +34,24 @@ class BarColor
      */
     public static function getColors(): array
     {
-        return self::$colors;
+        return array_keys(self::$colorNames);
+    }
+
+    /**
+     * Get color constant by color name.
+     *
+     * @param string $colorName
+     * @return int
+     * @throws \InvalidArgumentException
+     */
+    public static function getColorByName(string $colorName): int
+    {
+        $colorNameLower = strtolower($colorName);
+        foreach (self::$colorNames as $color => $name) {
+            if ($colorNameLower === strtolower($name)) {
+                return $color;
+            }
+        }
+        throw new \InvalidArgumentException("Invalid color name specified: " . $colorName);
     }
 }

--- a/src/xenialdan/apibossbar/BarColor.php
+++ b/src/xenialdan/apibossbar/BarColor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace xenialdan\apibossbar;
+
+use pocketmine\network\mcpe\protocol\types\BossBarColor;
+
+class BarColor
+{
+    const PINK = BossBarColor::PINK;
+    const BLUE = BossBarColor::BLUE;
+    const RED = BossBarColor::RED;
+    const GREEN = BossBarColor::GREEN;
+    const YELLOW = BossBarColor::YELLOW;
+    const PURPLE = BossBarColor::PURPLE;
+    const REBECCA_PURPLE = BossBarColor::REBECCA_PURPLE;
+    const WHITE = BossBarColor::WHITE;
+
+    /** @var int[] */
+    public static array $colors = [
+        self::PINK,
+        self::BLUE,
+        self::RED,
+        self::GREEN,
+        self::YELLOW,
+        self::PURPLE,
+        self::REBECCA_PURPLE,
+        self::WHITE,
+    ];
+
+    /**
+     * Get all available boss bar colors.
+     *
+     * @return int[]
+     */
+    public static function getColors(): array
+    {
+        return self::$colors;
+    }
+}

--- a/src/xenialdan/apibossbar/BossBar.php
+++ b/src/xenialdan/apibossbar/BossBar.php
@@ -189,6 +189,11 @@ class BossBar
             return $this->color;
         }
 
+        public static function getColorByName(string $colorName): int
+        {
+            return BarColor::getColorByName($colorName);
+        }
+
 	public function setColor(int $color): static
         {
             if (!in_array($color, BarColor::getColors(), true)) {

--- a/src/xenialdan/apibossbar/BossBar.php
+++ b/src/xenialdan/apibossbar/BossBar.php
@@ -1,436 +1,356 @@
 <?php
 
-
 namespace xenialdan\apibossbar;
 
+use GlobalLogger;
+use InvalidArgumentException;
 use pocketmine\entity\Attribute;
+use pocketmine\entity\AttributeFactory;
 use pocketmine\entity\AttributeMap;
-use pocketmine\entity\DataPropertyManager;
 use pocketmine\entity\Entity;
-use pocketmine\network\mcpe\protocol\AddActorPacket;
+use pocketmine\network\mcpe\NetworkBroadcastUtils;
 use pocketmine\network\mcpe\protocol\BossEventPacket;
 use pocketmine\network\mcpe\protocol\RemoveActorPacket;
-use pocketmine\network\mcpe\protocol\SetActorDataPacket;
+use pocketmine\network\mcpe\protocol\types\BossBarColor;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use pocketmine\network\mcpe\protocol\UpdateAttributesPacket;
-use pocketmine\Player;
+use pocketmine\player\Player;
 use pocketmine\Server;
-use pocketmine\utils\MainLogger;
 
 class BossBar
 {
-    protected const NETWORK_ID = Entity::SLIME;
+	/** @var Player[] */
+	private array $players = [];
+	private string $title = "";
+	private string $subTitle = "";
+	private int $color = BossBarColor::PURPLE;
+	public ?int $actorId = null;
+	private AttributeMap $attributeMap;
+	protected EntityMetadataCollection $propertyManager;
 
-    /** @var Player[] */
-    private $players = [];
-    /**
-     * @var string
-     */
-    private $title = "";
-    /**
-     * @var string
-     */
-    private $subTitle = "";
-    /**
-     * @var int|null
-     */
-    public $entityId = null;
-    /** @var AttributeMap */
-    private $attributeMap;
-    /** @var DataPropertyManager */
-    protected $propertyManager;
+	/**
+	 * BossBar constructor.
+	 * This will not spawn the bar, since there would be no players to spawn it to
+	 */
+	public function __construct(){
+		$this->attributeMap = new AttributeMap();
+		/** @var AttributeFactory $attributeFactory */
+		$attributeFactory = AttributeFactory::getInstance();
+		$this->getAttributeMap()->add($attributeFactory->mustGet(Attribute::HEALTH)->setMaxValue(100.0)->setMinValue(0.0)->setDefaultValue(100.0));
+		$this->propertyManager = new EntityMetadataCollection();
+		$this->propertyManager->setLong(EntityMetadataProperties::FLAGS, 0
+			^ 1 << EntityMetadataFlags::SILENT
+			^ 1 << EntityMetadataFlags::INVISIBLE
+			^ 1 << EntityMetadataFlags::NO_AI
+			^ 1 << EntityMetadataFlags::FIRE_IMMUNE);
+		$this->propertyManager->setShort(EntityMetadataProperties::MAX_AIR, 400);
+		$this->propertyManager->setString(EntityMetadataProperties::NAMETAG, $this->getFullTitle());
+		$this->propertyManager->setLong(EntityMetadataProperties::LEAD_HOLDER_EID, -1);
+		$this->propertyManager->setFloat(EntityMetadataProperties::SCALE, 0);
+		$this->propertyManager->setFloat(EntityMetadataProperties::BOUNDING_BOX_WIDTH, 0.0);
+		$this->propertyManager->setFloat(EntityMetadataProperties::BOUNDING_BOX_HEIGHT, 0.0);
+	}
 
-    /**
-     * BossBar constructor.
-     * This will not spawn the bar, since there would be no players to spawn it to
-     */
-    public function __construct()
-    {
-        $this->entityId = Entity::$entityCount++;
-        $this->attributeMap = new AttributeMap();
-        $this->getAttributeMap()->addAttribute(Attribute::getAttribute(Attribute::HEALTH)->setMaxValue(100.0)->setMinValue(0.0)->setDefaultValue(100.0));
-        $this->propertyManager = new DataPropertyManager();
-        $this->propertyManager->setLong(Entity::DATA_FLAGS, 0
-            ^ 1 << Entity::DATA_FLAG_SILENT
-            ^ 1 << Entity::DATA_FLAG_INVISIBLE
-            ^ 1 << Entity::DATA_FLAG_NO_AI
-            ^ 1 << Entity::DATA_FLAG_FIRE_IMMUNE);
-        $this->propertyManager->setShort(Entity::DATA_MAX_AIR, 400);
-        $this->propertyManager->setString(Entity::DATA_NAMETAG, $this->getFullTitle());
-        $this->propertyManager->setLong(Entity::DATA_LEAD_HOLDER_EID, -1);
-        $this->propertyManager->setFloat(Entity::DATA_SCALE, 0);
-        $this->propertyManager->setFloat(Entity::DATA_BOUNDING_BOX_WIDTH, 0.0);
-        $this->propertyManager->setFloat(Entity::DATA_BOUNDING_BOX_HEIGHT, 0.0);
-    }
+	/**
+	 * @return Player[]
+	 */
+	public function getPlayers(): array
+	{
+		return $this->players;
+	}
 
-    /**
-     * @return Player[]
-     */
-    public function getPlayers(): array
-    {
-        return $this->players;
-    }
+	/**
+	 * @param Player[] $players
+	 *
+	 * @return static
+	 */
+	public function addPlayers(array $players) : static{
+		foreach($players as $player){
+			$this->addPlayer($player);
+		}
+		return $this;
+	}
 
-    /**
-     * @param Player[] $players
-     * @return BossBar
-     */
-    public function addPlayers(array $players): BossBar
-    {
-        foreach ($players as $player) {
-            $this->addPlayer($player);
-        };
-        return $this;
-    }
+	public function addPlayer(Player $player) : static{
+		if(isset($this->players[$player->getId()])) return $this;
+		#if (!$this->getEntity() instanceof Player) $this->sendSpawnPacket([$player]);
+		$this->sendBossPacket([$player]);
+		$this->players[$player->getId()] = $player;
+		return $this;
+	}
 
-    /**
-     * @param Player $player
-     * @return BossBar
-     */
-    public function addPlayer(Player $player): BossBar
-    {
-        if (isset($this->players[$player->getId()])) return $this;
-        if (!$this->getEntity() instanceof Player) $this->sendSpawnPacket([$player]);
-        $this->sendBossPacket([$player]);
-        $this->players[$player->getId()] = $player;
-        return $this;
-    }
+	/**
+	 * Removes a single player from this bar.
+	 * Use @param Player $player
+	 * @return static
+	 * @see BossBar::hideFrom() when just removing temporarily to save some performance / bandwidth
+	 */
+	public function removePlayer(Player $player) : static{
+		if(!isset($this->players[$player->getId()])){
+			GlobalLogger::get()->debug("Removed player that was not added to the boss bar (" . $this . ")");
+			return $this;
+		}
+		$this->sendRemoveBossPacket([$player]);
+		unset($this->players[$player->getId()]);
+		return $this;
+	}
 
-    /**
-     * Removes a single player from this bar.
-     * Use @see BossBar::hideFrom() when just removing temporarily to save some performance / bandwidth
-     * @param Player $player
-     * @return BossBar
-     */
-    public function removePlayer(Player $player): BossBar
-    {
-        if (!isset($this->players[$player->getId()])) {
-            MainLogger::getLogger()->debug("Removed player that was not added to the boss bar (" . $this . ")");
-            return $this;
-        }
-        $this->sendRemoveBossPacket([$player]);
-        unset($this->players[$player->getId()]);
-        return $this;
-    }
+	/**
+	 * @param Player[] $players
+	 * @return static
+	 */
+	public function removePlayers(array $players) : static{
+		foreach($players as $player){
+			$this->removePlayer($player);
+		}
+		return $this;
+	}
 
-    /**
-     * @param Player[] $players
-     * @return BossBar
-     */
-    public function removePlayers(array $players): BossBar
-    {
-        foreach ($players as $player) {
-            $this->removePlayer($player);
-        };
-        return $this;
-    }
+	/**
+	 * Removes all players from this bar
+	 * @return static
+	 */
+	public function removeAllPlayers() : static{
+		foreach($this->getPlayers() as $player) $this->removePlayer($player);
+		return $this;
+	}
 
-    /**
-     * Removes all players from this bar
-     * @return BossBar
-     */
-    public function removeAllPlayers(): BossBar
-    {
-        foreach ($this->getPlayers() as $player) $this->removePlayer($player);
-        return $this;
-    }
+	/**
+	 * The text above the bar
+	 * @return string
+	 */
+	public function getTitle(): string
+	{
+		return $this->title;
+	}
 
+	/**
+	 * Text above the bar. Can be empty. Should be single-line
+	 * @param string $title
+	 * @return static
+	 */
+	public function setTitle(string $title = "") : static{
+		$this->title = $title;
+		$this->sendBossTextPacket($this->getPlayers());
+		return $this;
+	}
 
-    /**
-     * The text above the bar
-     * @return string
-     */
-    public function getTitle(): string
-    {
-        return $this->title;
-    }
+	public function getSubTitle(): string
+	{
+		return $this->subTitle;
+	}
 
-    /**
-     * Text above the bar. Can be empty. Should be single-line
-     * @param string $title
-     * @return BossBar
-     */
-    public function setTitle(string $title = ""): BossBar
-    {
-        $this->title = $title;
-        #$this->sendEntityDataPacket($this->getPlayers());
-        $this->sendBossTextPacket($this->getPlayers());
-        return $this;
-    }
+	/**
+	 * Optional text below the bar. Can be empty
+	 * @param string $subTitle
+	 * @return static
+	 */
+	public function setSubTitle(string $subTitle = "") : static{
+		$this->subTitle = $subTitle;
+		#$this->sendEntityDataPacket($this->getPlayers());
+		$this->sendBossTextPacket($this->getPlayers());
+		return $this;
+	}
 
-    /**
-     * @return string
-     */
-    public function getSubTitle(): string
-    {
-        return $this->subTitle;
-    }
+	/**
+	 * The full title as a combination of the title and its subtitle. Automatically fixes encoding issues caused by newline characters
+	 * @return string
+	 */
+	public function getFullTitle(): string
+	{
+		$text = $this->title;
+		if (!empty($this->subTitle)) {
+			$text .= "\n\n" . $this->subTitle;
+		}
+		return mb_convert_encoding($text, 'UTF-8');
+	}
 
-    /**
-     * Optional text below the bar. Can be empty
-     * @param string $subTitle
-     * @return BossBar
-     */
-    public function setSubTitle(string $subTitle = ""): BossBar
-    {
-        $this->subTitle = $subTitle;
-        #$this->sendEntityDataPacket($this->getPlayers());
-        $this->sendBossTextPacket($this->getPlayers());
-        return $this;
-    }
+	/**
+	 * @param float $percentage 0-1
+	 * @return static
+	 */
+	public function setPercentage(float $percentage) : static{
+		$percentage = (float) min(1.0, max(0.0, $percentage));
+		$this->getAttributeMap()->get(Attribute::HEALTH)->setValue($percentage * $this->getAttributeMap()->get(Attribute::HEALTH)->getMaxValue(), true, true);
+		#$this->sendAttributesPacket($this->getPlayers());
+		$this->sendBossHealthPacket($this->getPlayers());
 
-    /**
-     * The full title as a combination of the title and its subtitle. Automatically fixes encoding issues caused by newline characters
-     * @return string
-     */
-    public function getFullTitle(): string
-    {
-        $text = $this->title;
-        if (!empty($this->subTitle)) {
-            $text .= "\n\n" . $this->subTitle;
-        }
-        return mb_convert_encoding($text, 'UTF-8');
-    }
+		return $this;
+	}
 
-    /**
-     * @param float $percentage 0-1
-     * @return BossBar
-     */
-    public function setPercentage(float $percentage): BossBar
-    {
-        $percentage = (float)max(0.0, $percentage);
-        $this->getAttributeMap()->getAttribute(Attribute::HEALTH)->setValue($percentage* $this->getAttributeMap()->getAttribute(Attribute::HEALTH)->getMaxValue(), true, true);
-        $this->sendAttributesPacket($this->getPlayers());
-        $this->sendBossHealthPacket($this->getPlayers());
+	public function getPercentage() : float{
+		return $this->getAttributeMap()->get(Attribute::HEALTH)->getValue() / 100;
+	}
 
-        return $this;
-    }
+	public function getColor() : int{
+		return $this->color;
+	}
 
-    /**
-     * @return float
-     */
-    public function getPercentage(): float
-    {
-        return $this->getAttributeMap()->getAttribute(Attribute::HEALTH)->getValue()/100;
-    }
+	public function setColor(int $color) : static{
+		$this->color = $color;
+		$this->sendBossPacket($this->getPlayers());
 
-    /**
-     * TODO: Only registered players validation
-     * Hides the bar from the specified players without removing it.
-     * Useful when saving some bandwidth or when you'd like to keep the entity
-     * @param Player[] $players
-     */
-    public function hideFrom(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_HIDE;
-        Server::getInstance()->broadcastPacket($players, $pk);
-    }
+		return $this;
+	}
 
-    /**
-     * Hides the bar from all registered players
-     */
-    public function hideFromAll(): void
-    {
-        $this->hideFrom($this->getPlayers());
-    }
+	/**
+	 * TODO: Only registered players validation
+	 * Hides the bar from the specified players without removing it.
+	 * Useful when saving some bandwidth or when you'd like to keep the entity
+	 *
+	 * @param Player[] $players
+	 */
+	public function hideFrom(array $players) : void{
+		foreach ($players as $player) {
+			if (!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::hide($this->actorId ?? $player->getId()));
+		}
+	}
 
-    /**
-     * TODO: Only registered players validation
-     * Displays the bar to the specified players
-     * @param Player[] $players
-     */
-    public function showTo(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_SHOW;
-        Server::getInstance()->broadcastPacket($players, $this->addDefaults($pk));
-    }
+	/**
+	 * Hides the bar from all registered players
+	 */
+	public function hideFromAll(): void
+	{
+		$this->hideFrom($this->getPlayers());
+	}
 
-    /**
-     * Displays the bar to all registered players
-     */
-    public function showToAll(): void
-    {
-        $this->showTo($this->getPlayers());
-    }
+	/**
+	 * TODO: Only registered players validation
+	 * Displays the bar to the specified players
+	 * @param Player[] $players
+	 */
+	public function showTo(array $players): void
+	{
+		$this->sendBossPacket($players);
+	}
 
-    /**
-     * @return null|Entity
-     */
-    public function getEntity(): ?Entity
-    {
-        return Server::getInstance()->findEntity($this->entityId);
-    }
+	/**
+	 * Displays the bar to all registered players
+	 */
+	public function showToAll(): void
+	{
+		$this->showTo($this->getPlayers());
+	}
 
-    /**
-     * STILL TODO, SHOULD NOT BE USED YET
-     * @param null|Entity $entity
-     * @return BossBar
-     * TODO: use attributes and properties of the custom entity
-     */
-    public function setEntity(?Entity $entity = null): BossBar
-    {
-        if ($entity instanceof Entity && ($entity->isClosed() || $entity->isFlaggedForDespawn())) throw new \InvalidArgumentException("Entity $entity can not be used since its not valid anymore (closed or flagged for despawn)");
-        if ($this->getEntity() instanceof Entity && !$entity instanceof Player) $this->getEntity()->flagForDespawn();
-        else {
-            $pk = new RemoveActorPacket();
-            $pk->entityUniqueId = $this->entityId;
-            Server::getInstance()->broadcastPacket($this->getPlayers(), $pk);
-        }
-        if ($entity instanceof Entity) {
-            $this->entityId = $entity->getId();
-            $this->attributeMap = $entity->getAttributeMap();//TODO try some kind of auto-updating reference
-            $this->getAttributeMap()->addAttribute($entity->getAttributeMap()->getAttribute(Attribute::HEALTH));//TODO Auto-update bar for entity? Would be cool, so the api can be used for actual bosses
-            $this->propertyManager = $entity->getDataPropertyManager();
-            if(!$entity instanceof Player) $entity->despawnFromAll();
-        } else {
-            $this->entityId = Entity::$entityCount++;
-        }
-        if(!$entity instanceof Player) $this->sendSpawnPacket($this->getPlayers());
-        $this->sendBossPacket($this->getPlayers());
-        return $this;
-    }
+	public function getEntity(): ?Entity
+	{
+		if ($this->actorId === null) return null;
+		return Server::getInstance()->getWorldManager()->findEntity($this->actorId);
+	}
 
-    /**
-     * @param bool $removeEntity Be careful with this. If set to true, the entity will be deleted.
-     * @return BossBar
-     */
-    public function resetEntity(bool $removeEntity = false): BossBar
-    {
-        if ($removeEntity && $this->getEntity() instanceof Entity && !$this->getEntity() instanceof Player) $this->getEntity()->close();
-        return $this->setEntity();
-    }
+	/**
+	 * STILL TODO, SHOULD NOT BE USED YET
+	 * @param null|Entity $entity
+	 * @return static
+	 * TODO: use attributes and properties of the custom entity
+	 */
+	public function setEntity(?Entity $entity = null) : static{
+		if($entity instanceof Entity && ($entity->isClosed() || $entity->isFlaggedForDespawn())) throw new InvalidArgumentException("Entity $entity can not be used since its not valid anymore (closed or flagged for despawn)");
+		if($this->getEntity() instanceof Entity && !$entity instanceof Player) $this->getEntity()->flagForDespawn();
+		else{
+			$pk = new RemoveActorPacket();
+			$pk->actorUniqueId = $this->actorId;
+			NetworkBroadcastUtils::broadcastPackets($this->getPlayers(), [$pk]);
+		}
+		if($entity instanceof Entity){
+			$this->actorId = $entity->getId();
+			$this->attributeMap = $entity->getAttributeMap();//TODO try some kind of auto-updating reference
+			$this->getAttributeMap()->add($entity->getAttributeMap()->get(Attribute::HEALTH));//TODO Auto-update bar for entity? Would be cool, so the api can be used for actual bosses
+			$this->propertyManager = $entity->getNetworkProperties();
+			if(!$entity instanceof Player) $entity->despawnFromAll();//TODO figure out why this is even here
+		} else {
+			$this->actorId = Entity::nextRuntimeId();
+		}
+		#if (!$entity instanceof Player) $this->sendSpawnPacket($this->getPlayers());
+		$this->sendBossPacket($this->getPlayers());
+		return $this;
+	}
 
-    /**
-     * TODO if entity exists and is spawned, don't send again
-     * TODO slime is not needed anymore. Use player
-     * @param Player[] $players
-     */
-    protected function sendSpawnPacket(array $players): void
-    {
-        $pk = new AddActorPacket();
-        $pk->entityRuntimeId = $this->entityId;
-        $pk->type = AddActorPacket::LEGACY_ID_MAP_BC[$this->getEntity() instanceof Entity ? $this->getEntity()::NETWORK_ID : static::NETWORK_ID];
-        $pk->attributes = $this->getAttributeMap()->getAll();
-        var_dump($this->getPropertyManager()->getAll());
-        $pk->metadata = $this->getPropertyManager()->getAll();
-        foreach ($players as $player) {
-            $pkc = clone $pk;
-            $pkc->position = $player->asVector3()->subtract(0, 28);
-            $player->dataPacket($pkc);
-        }
-    }
+	/**
+	 * @param bool $removeEntity Be careful with this. If set to true, the entity will be deleted.
+	 * @return static
+	 */
+	public function resetEntity(bool $removeEntity = false) : static{
+		if($removeEntity && $this->getEntity() instanceof Entity && !$this->getEntity() instanceof Player) $this->getEntity()->close();
+		return $this->setEntity();
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendBossPacket(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_SHOW;
-        $pk->title = $this->getFullTitle();
-        $pk->healthPercent = $this->getPercentage();
-        Server::getInstance()->broadcastPacket($players, $this->addDefaults($pk));
-    }
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendBossPacket(array $players): void
+	{
+		foreach ($players as $player) {
+			if (!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::show($this->actorId ?? $player->getId(), $this->getFullTitle(), $this->getPercentage(), false, $this->getColor()));
+		}
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendRemoveBossPacket(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_HIDE;
-        Server::getInstance()->broadcastPacket($players, $pk);
-    }
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendRemoveBossPacket(array $players): void
+	{
+		foreach ($players as $player) {
+			if (!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::hide($this->actorId ?? $player->getId()));
+		}
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendBossTextPacket(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_TITLE;
-        $pk->title = $this->getFullTitle();
-        Server::getInstance()->broadcastPacket($players, $pk);
-    }
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendBossTextPacket(array $players): void
+	{
+		foreach ($players as $player) {
+			if (!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::title($this->actorId ?? $player->getId(), $this->getFullTitle()));
+		}
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendAttributesPacket(array $players): void
-    {
-        $pk = new UpdateAttributesPacket();
-        $pk->entityRuntimeId = $this->entityId;
-        $pk->entries = $this->getAttributeMap()->needSend();
-        Server::getInstance()->broadcastPacket($players, $pk);
-    }
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendAttributesPacket(array $players): void
+	{//TODO might not be needed anymore
+		if ($this->actorId === null) return;
+		$pk = new UpdateAttributesPacket();
+		$pk->actorRuntimeId = $this->actorId;
+		$pk->entries = $this->getAttributeMap()->needSend();
+		NetworkBroadcastUtils::broadcastPackets($players, [$pk]);
+	}
 
-    /**
-     * @param Player[] $players
-     *@deprecated
-     */
-    protected function sendEntityDataPacket(array $players): void
-    {
-        return;
-        $this->getPropertyManager()->setString(Entity::DATA_NAMETAG, $this->getFullTitle());
-        $pk = new SetActorDataPacket();
-        $pk->metadata = $this->getPropertyManager()->getDirty();
-        $pk->entityRuntimeId = $this->entityId;
-        Server::getInstance()->broadcastPacket($players, $pk);
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendBossHealthPacket(array $players): void
+	{
+		foreach ($players as $player) {
+			if (!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::healthPercent($this->actorId ?? $player->getId(), $this->getPercentage()));
+		}
+	}
 
-        $this->getPropertyManager()->clearDirtyProperties();
-    }
+	public function __toString(): string{
+		return __CLASS__ . " ID: $this->actorId, Players: " . count($this->players) . ", Title: \"$this->title\", Subtitle: \"$this->subTitle\", Percentage: \"" . $this->getPercentage() . "\", Color: \"" . $this->color . "\"";
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendBossHealthPacket(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_HEALTH_PERCENT;
-        $pk->healthPercent = $this->getPercentage();
-        Server::getInstance()->broadcastPacket($players, $pk);
-    }
+	/**
+	 * @param Player|null $player Only used for DiverseBossBar
+	 * @return AttributeMap
+	 */
+	public function getAttributeMap(Player $player = null): AttributeMap
+	{
+		return $this->attributeMap;
+	}
 
-    private function addDefaults(BossEventPacket $pk):BossEventPacket{
-        $pk->title = $this->getFullTitle();
-        $pk->healthPercent = $this->getPercentage();
-        $pk->unknownShort = 1;
-        $pk->color = 0;//Does not function anyways
-        $pk->overlay = 0;//Neither. Typical for Mojang: Copy-pasted from Java edition
-        return $pk;
-    }
+	protected function getPropertyManager(): EntityMetadataCollection
+	{
+		return $this->propertyManager;
+	}
 
-    /**
-     * @return string
-     */
-    public function __toString(): string
-    {
-        return __CLASS__ . " ID: $this->entityId, Players: " . count($this->players) . ", Title: \"$this->title\", Subtitle: \"$this->subTitle\", Percentage: \"".$this->getPercentage()."\"";
-    }
-
-    /**
-     * @param Player|null $player Only used for DiverseBossBar
-     * @return AttributeMap
-     */
-    public function getAttributeMap(Player $player = null): AttributeMap
-    {
-        return $this->attributeMap;
-    }
-
-    /**
-     * @return DataPropertyManager
-     */
-    protected function getPropertyManager(): DataPropertyManager
-    {
-        return $this->propertyManager;
-    }
-
-    //TODO callable on client2server register/unregister request
+	//TODO callable on client2server register/unregister request
 }

--- a/src/xenialdan/apibossbar/BossBar.php
+++ b/src/xenialdan/apibossbar/BossBar.php
@@ -184,16 +184,21 @@ class BossBar
 		return $this->getAttributeMap()->get(Attribute::HEALTH)->getValue() / 100;
 	}
 
-	public function getColor() : int{
-		return $this->color;
-	}
+	public function getColor(): int
+        {
+            return $this->color;
+        }
 
-	public function setColor(int $color) : static{
-		$this->color = $color;
-		$this->sendBossPacket($this->getPlayers());
+	public function setColor(int $color): static
+        {
+            if (!in_array($color, BarColor::getColors(), true)) {
+                throw new \InvalidArgumentException("Invalid color specified.");
+            }
 
-		return $this;
-	}
+            $this->color = $color;
+            $this->sendBossPacket($this->getPlayers());
+            return $this;
+        }
 
 	/**
 	 * TODO: Only registered players validation

--- a/src/xenialdan/apibossbar/DiverseBossBar.php
+++ b/src/xenialdan/apibossbar/DiverseBossBar.php
@@ -9,6 +9,7 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use pocketmine\network\mcpe\protocol\UpdateAttributesPacket;
 use pocketmine\player\Player;
+use xenialdan\apibossbar\BarColor;
 
 /**
  * Class DiverseBossBar
@@ -138,22 +139,25 @@ class DiverseBossBar extends BossBar
 	}
 
 	/**
-	 * @param Player[] $players
-	 * @param int      $color
-	 *
-	 * @return static
-	 */
-	public function setColorFor(array $players, int $color) : static{
-		foreach($players as $player){
-			$this->colors[$player->getId()] = $color;
-			$this->sendBossPacket([$player]);
-		}
-		return $this;
-	}
+         * @param Player[] $players
+         * @param string   $colorName
+         *
+         * @return static
+         */
+        public function setColorFor(array $players, string $colorName) : static{
+            $color = BarColor::getColorByName($colorName);
+            foreach($players as $player){
+                $this->colors[$player->getId()] = $color;
+                $this->sendBossPacket([$player]);
+            }
+            return $this;
+        }
 
-	public function getColorFor(Player $player) : int{
-		return $this->colors[$player->getId()] ?? $this->getColor();
-	}
+	public function getColorFor(Player $player): string
+        {
+            $colorId = $this->colors[$player->getId()] ?? $this->getColor();
+            return BarColor::$colorNames[$colorId] ?? "unknown";
+        }
 
 	/**
 	 * TODO: Only registered players validation

--- a/src/xenialdan/apibossbar/DiverseBossBar.php
+++ b/src/xenialdan/apibossbar/DiverseBossBar.php
@@ -1,302 +1,240 @@
 <?php
 
-
 namespace xenialdan\apibossbar;
-
 
 use pocketmine\entity\Attribute;
 use pocketmine\entity\AttributeMap;
-use pocketmine\entity\DataPropertyManager;
-use pocketmine\entity\Entity;
-use pocketmine\network\mcpe\protocol\AddActorPacket;
 use pocketmine\network\mcpe\protocol\BossEventPacket;
-use pocketmine\network\mcpe\protocol\SetActorDataPacket;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
+use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use pocketmine\network\mcpe\protocol\UpdateAttributesPacket;
-use pocketmine\Player;
+use pocketmine\player\Player;
 
 /**
  * Class DiverseBossBar
  * This Bar should be used if the data is different for each player
+ * This means if you want coordinates or player names in the title, you must use this!
  * You can use methods of @see BossBar to set defaults
  * @package xenialdan\apibossbar
  */
 class DiverseBossBar extends BossBar
 {
-    private $titles = [];
-    private $subTitles = [];
-    /** @var AttributeMap[] */
-    private $attributeMaps = [];
+	private array $titles = [];
+	private array $subTitles = [];
+	/** @var AttributeMap[] */
+	private array $attributeMaps = [];
+	private array $colors = [];
 
-    /**
-     * DiverseBossBar constructor.
-     * @see BossBar::__construct
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
+	/**
+	 * DiverseBossBar constructor.
+	 * @see BossBar::__construct
+	 * TODO might be useless, remove?
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
 
-    /**
-     * @param Player $player
-     * @return BossBar
-     */
-    public function addPlayer(Player $player): BossBar
-    {
-        $this->attributeMaps[$player->getId()] = clone parent::getAttributeMap();
-        return parent::addPlayer($player);
-    }
+	public function addPlayer(Player $player) : static{
+		$this->attributeMaps[$player->getId()] = clone parent::getAttributeMap();
+		return parent::addPlayer($player);
+	}
 
-    /**
-     * Removes a single player from this bar.
-     * Use @see BossBar::hideFrom() when just removing temporarily to save some performance / bandwidth
-     * @param Player $player
-     * @return BossBar
-     */
-    public function removePlayer(Player $player): BossBar
-    {
-        unset($this->attributeMaps[$player->getId()]);
-        return parent::removePlayer($player);
-    }
+	/**
+	 * Removes a single player from this bar.
+	 * Use @param Player $player
+	 * @return static
+	 * @see BossBar::hideFrom() when just removing temporarily to save some performance / bandwidth
+	 */
+	public function removePlayer(Player $player) : static{
+		unset($this->attributeMaps[$player->getId()]);
+		return parent::removePlayer($player);
+	}
 
-    public function resetFor(Player $player): DiverseBossBar
-    {
-        unset($this->attributeMaps[$player->getId()], $this->titles[$player->getId()], $this->subTitles[$player->getId()]);
-        $this->sendAttributesPacket([$player]);
-        $this->sendBossPacket([$player]);
-        return $this;
-    }
+	public function resetFor(Player $player) : static{
+		unset($this->attributeMaps[$player->getId()], $this->titles[$player->getId()], $this->subTitles[$player->getId()], $this->colors[$player->getId()]);
+		$this->sendAttributesPacket([$player]);
+		$this->sendBossPacket([$player]);
+		return $this;
+	}
 
-    public function resetForAll(): DiverseBossBar
-    {
-        foreach ($this->getPlayers() as $player) {
-            $this->resetFor($player);
-        };
-        return $this;
-    }
+	public function resetForAll() : static{
+		foreach($this->getPlayers() as $player){
+			$this->resetFor($player);
+		}
+		return $this;
+	}
 
-    public function getTitleFor(Player $player): string
-    {
-        return $this->titles[$player->getId()] ?? $this->getTitle();
-    }
+	public function getTitleFor(Player $player): string
+	{
+		return $this->titles[$player->getId()] ?? $this->getTitle();
+	}
 
-    /**
-     * @param Player[] $players
-     * @param string $title
-     * @return DiverseBossBar
-     */
-    public function setTitleFor(array $players, string $title = ""): DiverseBossBar
-    {
-        foreach ($players as $player) {
-            $this->titles[$player->getId()] = $title;
-            #$this->sendEntityDataPacket([$player]);
-            $this->sendBossTextPacket([$player]);
-        }
-        return $this;
-    }
+	/**
+	 * @param Player[] $players
+	 * @param string   $title
+	 *
+	 * @return static
+	 */
+	public function setTitleFor(array $players, string $title = "") : static{
+		foreach($players as $player){
+			$this->titles[$player->getId()] = $title;
+			$this->sendBossTextPacket([$player]);
+		}
+		return $this;
+	}
 
-    public function getSubTitleFor(Player $player): string
-    {
-        return $this->subTitles[$player->getId()] ?? $this->getSubTitle();
-    }
+	public function getSubTitleFor(Player $player): string
+	{
+		return $this->subTitles[$player->getId()] ?? $this->getSubTitle();
+	}
 
-    /**
-     * @param Player[] $players
-     * @param string $subTitle
-     * @return DiverseBossBar
-     */
-    public function setSubTitleFor(array $players, string $subTitle = ""): DiverseBossBar
-    {
-        foreach ($players as $player) {
-            $this->subTitles[$player->getId()] = $subTitle;
-            #$this->sendEntityDataPacket([$player]);
-            $this->sendBossTextPacket([$player]);
-        }
-        return $this;
-    }
+	/**
+	 * @param Player[] $players
+	 * @param string   $subTitle
+	 * @return static
+	 */
+	public function setSubTitleFor(array $players, string $subTitle = "") : static{
+		foreach($players as $player){
+			$this->subTitles[$player->getId()] = $subTitle;
+			$this->sendBossTextPacket([$player]);
+		}
+		return $this;
+	}
 
-    /**
-     * The full title as a combination of the title and its subtitle. Automatically fixes encoding issues caused by newline characters
-     * @param Player $player
-     * @return string
-     */
-    public function getFullTitleFor(Player $player): string
-    {
-        $text = $this->titles[$player->getId()] ?? "";
-        if (!empty($this->subTitles[$player->getId()] ?? "")) {
-            $text .= "\n\n" . $this->subTitles[$player->getId()] ?? "";//?? "" even necessary?
-        }
-        if (empty($text)) $text = $this->getFullTitle();
-        return mb_convert_encoding($text, 'UTF-8');
-    }
+	/**
+	 * The full title as a combination of the title and its subtitle. Automatically fixes encoding issues caused by newline characters
+	 * @param Player $player
+	 * @return string
+	 */
+	public function getFullTitleFor(Player $player): string
+	{
+		$text = $this->titles[$player->getId()] ?? "";
+		if (!empty($this->subTitles[$player->getId()] ?? "")) {
+			$text .= "\n\n" . $this->subTitles[$player->getId()] ?? "";//?? "" even necessary?
+		}
+		if (empty($text)) $text = $this->getFullTitle();
+		return mb_convert_encoding($text, 'UTF-8');
+	}
 
-    /**
-     * @param Player[] $players
-     * @param float $percentage 0-1
-     * @return DiverseBossBar
-     */
-    public function setPercentageFor(array $players, float $percentage): DiverseBossBar
-    {
-        $percentage = (float)max(0.00, $percentage);
-        foreach ($players as $player) {
-            $this->getAttributeMap($player)->getAttribute(Attribute::HEALTH)->setValue($percentage * $this->getAttributeMap($player)->getAttribute(Attribute::HEALTH)->getMaxValue(), true, true);
-        }
-        $this->sendAttributesPacket($players);
-        $this->sendBossHealthPacket($players);
+	/**
+	 * @param Player[] $players
+	 * @param float    $percentage 0-1
+	 * @return static
+	 */
+	public function setPercentageFor(array $players, float $percentage) : static{
+		$percentage = (float) min(1.0, max(0.00, $percentage));
+		foreach($players as $player){
+			$this->getAttributeMap($player)->get(Attribute::HEALTH)->setValue($percentage * $this->getAttributeMap($player)->get(Attribute::HEALTH)->getMaxValue(), true, true);
+		}
+		$this->sendAttributesPacket($players);
+		$this->sendBossHealthPacket($players);
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * @param Player $player
-     * @return float
-     */
-    public function getPercentageFor(Player $player): float
-    {
-        return $this->getAttributeMap($player)->getAttribute(Attribute::HEALTH)->getValue() / 100;
-    }
+	public function getPercentageFor(Player $player) : float{
+		return $this->getAttributeMap($player)->get(Attribute::HEALTH)->getValue() / 100;
+	}
 
-    /**
-     * TODO: Only registered players validation
-     * Displays the bar to the specified players
-     * @param Player[] $players
-     */
-    public function showTo(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_SHOW;
-        foreach ($players as $player) {
-            $player->sendDataPacket($this->addDefaults($player, clone $pk));
-        }
-    }
+	/**
+	 * @param Player[] $players
+	 * @param int      $color
+	 *
+	 * @return static
+	 */
+	public function setColorFor(array $players, int $color) : static{
+		foreach($players as $player){
+			$this->colors[$player->getId()] = $color;
+			$this->sendBossPacket([$player]);
+		}
+		return $this;
+	}
 
-    /**
-     * @param Player[] $players
-     *@deprecated
-     */
-    protected function sendSpawnPacket(array $players): void
-    {
-        $pk = new AddActorPacket();
-        $pk->entityRuntimeId = $this->entityId;
-        $pk->type = AddActorPacket::LEGACY_ID_MAP_BC[$this->getEntity() instanceof Entity ? $this->getEntity()::NETWORK_ID : static::NETWORK_ID];
-        foreach ($players as $player) {
-            $pkc = clone $pk;
-            $pkc->attributes = $this->getAttributeMap($player)->getAll();
-            $pkc->metadata = $this->getPropertyManager($player)->getAll();
-            #var_dump($this->getPropertyManager()->getAll());
-            $pkc->position = $player->asVector3()->subtract(0, 28);
-            $player->dataPacket($pkc);
-        }
-    }
+	public function getColorFor(Player $player) : int{
+		return $this->colors[$player->getId()] ?? $this->getColor();
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendBossPacket(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_SHOW;
-        foreach ($players as $player) {
-            $pkc = clone $pk;
-            $pkc->title = $this->getFullTitleFor($player);
-            $pkc->healthPercent = $this->getPercentageFor($player);
-            $player->dataPacket($this->addDefaults($player, $pkc));
-        }
-    }
+	/**
+	 * TODO: Only registered players validation
+	 * Displays the bar to the specified players
+	 *
+	 * @param Player[] $players
+	 */
+	public function showTo(array $players) : void{
+		foreach ($players as $player) {
+			if(!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::show($this->actorId ?? $player->getId(), $this->getFullTitleFor($player), $this->getPercentageFor($player), false, $this->getColorFor($player)));
+		}
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendBossTextPacket(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_TITLE;
-        foreach ($players as $player) {
-            $pkc = clone $pk;
-            $pkc->title = $this->getFullTitleFor($player);
-            $player->dataPacket($pkc);
-        }
-    }
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendBossPacket(array $players): void
+	{
+		foreach ($players as $player) {
+			if(!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::show($this->actorId ?? $player->getId(), $this->getFullTitleFor($player), $this->getPercentageFor($player), false, $this->getColorFor($player)));
+		}
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendAttributesPacket(array $players): void
-    {
-        $pk = new UpdateAttributesPacket();
-        $pk->entityRuntimeId = $this->entityId;
-        foreach ($players as $player) {
-            $pkc = clone $pk;
-            $pk->entries = $this->getAttributeMap($player)->needSend();
-            $player->dataPacket($pkc);
-        }
-    }
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendBossTextPacket(array $players): void
+	{
+		foreach ($players as $player) {
+			if(!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::title($this->actorId ?? $player->getId(), $this->getFullTitleFor($player)));
+		}
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendEntityDataPacket(array $players): void
-    {
-        $pk = new SetActorDataPacket();
-        $pk->entityRuntimeId = $this->entityId;
-        foreach ($players as $player) {
-            //$this->getPropertyManager($player)->setString(Entity::DATA_NAMETAG, $this->getFullTitleFor($player));
-            $pkc = clone $pk;
-            $pkc->metadata = $this->getPropertyManager($player)->getDirty();
-            $player->dataPacket($pkc);
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendAttributesPacket(array $players): void
+	{//TODO might not be needed anymore
+		if ($this->actorId === null) return;
+		$pk = new UpdateAttributesPacket();
+		$pk->actorRuntimeId = $this->actorId;
+		foreach ($players as $player) {
+			if(!$player->isConnected()) continue;
+			$pk->entries = $this->getAttributeMap($player)->needSend();
+			$player->getNetworkSession()->sendDataPacket($pk);
+		}
+	}
 
-            //$this->getPropertyManager($player)->clearDirtyProperties();
-        }
-    }
+	/**
+	 * @param Player[] $players
+	 */
+	protected function sendBossHealthPacket(array $players): void
+	{
+		foreach ($players as $player) {
+			if(!$player->isConnected()) continue;
+			$player->getNetworkSession()->sendDataPacket(BossEventPacket::healthPercent($this->actorId ?? $player->getId(), $this->getPercentageFor($player)));
+		}
+	}
 
-    /**
-     * @param Player[] $players
-     */
-    protected function sendBossHealthPacket(array $players): void
-    {
-        $pk = new BossEventPacket();
-        $pk->bossEid = $this->entityId;
-        $pk->eventType = BossEventPacket::TYPE_HEALTH_PERCENT;
-        foreach ($players as $player) {
-            $pkc = clone $pk;
-            $pkc->healthPercent = $this->getPercentageFor($player);
-            $player->dataPacket($pkc);
-        }
-    }
+	public function getAttributeMap(Player $player = null): AttributeMap
+	{
+		if ($player instanceof Player) {
+			return $this->attributeMaps[$player->getId()] ?? parent::getAttributeMap();
+		}
+		return parent::getAttributeMap();
+	}
 
-    private function addDefaults(Player $player, BossEventPacket $pk): BossEventPacket
-    {
-        $pk->title = $this->getFullTitleFor($player);
-        $pk->healthPercent = $this->getPercentageFor($player);
-        $pk->unknownShort = 1;
-        $pk->color = 0;//Does not function anyways
-        $pk->overlay = 0;//neither. Typical for Mojang: Copy-pasted from Java edition
-        return $pk;
-    }
+	public function getPropertyManager(Player $player = null): EntityMetadataCollection
+	{
+		$propertyManager = /*clone*/
+			$this->propertyManager;//TODO check if memleak
+		if ($player instanceof Player) $propertyManager->setString(EntityMetadataProperties::NAMETAG, $this->getFullTitleFor($player));
+		else $propertyManager->setString(EntityMetadataProperties::NAMETAG, $this->getFullTitle());
+		return $propertyManager;
+	}
 
-    public function getAttributeMap(Player $player = null): AttributeMap
-    {
-        if ($player instanceof Player) {
-            $attributeMap = $this->attributeMaps[$player->getId()] ?? parent::getAttributeMap();
-        } else $attributeMap = parent::getAttributeMap();
-        return $attributeMap;
-    }
-
-    public function getPropertyManager(Player $player = null): DataPropertyManager
-    {
-        $propertyManager = clone $this->propertyManager;//TODO check if memleak
-        if ($player instanceof Player) $propertyManager->setString(Entity::DATA_NAMETAG, $this->getFullTitleFor($player));
-        else $propertyManager->setString(Entity::DATA_NAMETAG, $this->getFullTitle());
-        return $propertyManager;
-    }
-
-    /**
-     * @return string
-     */
-    public function __toString(): string
-    {
-        return __CLASS__ . " ID: $this->entityId, Titles: " . count($this->titles) . ", Subtitles: " . count($this->subTitles) . " [Defaults: " . parent::__toString() . "]";
-    }
+	public function __toString(): string
+	{
+		return __CLASS__ . " ID: $this->actorId, Titles: " . count($this->titles) . ", Subtitles: " . count($this->subTitles) . " [Defaults: " . parent::__toString() . "]";
+	}
 }

--- a/src/xenialdan/apibossbar/PacketListener.php
+++ b/src/xenialdan/apibossbar/PacketListener.php
@@ -2,6 +2,7 @@
 
 namespace xenialdan\apibossbar;
 
+use InvalidArgumentException;
 use pocketmine\event\Listener;
 use pocketmine\event\server\DataPacketReceiveEvent;
 use pocketmine\network\mcpe\protocol\BossEventPacket;
@@ -10,54 +11,50 @@ use pocketmine\Server;
 
 class PacketListener implements Listener
 {
-    /** @var Plugin|null */
-    private static $registrant;
+	private static ?Plugin $registrant;
 
-    public static function isRegistered(): bool
-    {
-        return self::$registrant instanceof Plugin;
-    }
+	public static function isRegistered(): bool
+	{
+		return self::$registrant instanceof Plugin;
+	}
 
-    public static function getRegistrant(): Plugin
-    {
-        return self::$registrant;
-    }
+	public static function getRegistrant(): Plugin
+	{
+		return self::$registrant;
+	}
 
-    public static function unregister(): void
-    {
-        self::$registrant = null;
-    }
+	public static function unregister(): void
+	{
+		self::$registrant = null;
+	}
 
-    /**
-     * @param Plugin $plugin
-     */
-    public static function register(Plugin $plugin): void
-    {
-        if (self::isRegistered()) {
-            return;//silent return
-        }
+	public static function register(Plugin $plugin): void
+	{
+		if (self::isRegistered()) {
+			return;//silent return
+		}
 
-        self::$registrant = $plugin;
-        $plugin->getServer()->getPluginManager()->registerEvents(new self, $plugin);
-    }
+		self::$registrant = $plugin;
+		$plugin->getServer()->getPluginManager()->registerEvents(new self, $plugin);
+	}
 
-    public function onDataPacketReceiveEvent(DataPacketReceiveEvent $e)
-    {
-        if ($e->getPacket() instanceof BossEventPacket) $this->onBossEventPacket($e);
-    }
+	public function onDataPacketReceiveEvent(DataPacketReceiveEvent $e)
+	{
+		if ($e->getPacket() instanceof BossEventPacket) $this->onBossEventPacket($e);
+	}
 
-    private function onBossEventPacket(DataPacketReceiveEvent $e)
-    {
-        if (!($pk = $e->getPacket()) instanceof BossEventPacket) throw new \InvalidArgumentException(get_class($e->getPacket()) . " is not a " . BossEventPacket::class);
-        /** @var BossEventPacket $pk */
-        switch ($pk->eventType) {
-            case BossEventPacket::TYPE_REGISTER_PLAYER:
-            case BossEventPacket::TYPE_UNREGISTER_PLAYER:
-                Server::getInstance()->getLogger()->debug("Got BossEventPacket " . ($pk->eventType === BossEventPacket::TYPE_REGISTER_PLAYER ? "" : "un") . "register by client for player id " . $pk->playerEid);
-                break;
-            default:
-                $e->getPlayer()->kick("Invalid packet received", false);
-        }
-    }
+	private function onBossEventPacket(DataPacketReceiveEvent $e)
+	{
+		if (!($pk = $e->getPacket()) instanceof BossEventPacket) throw new InvalidArgumentException(get_class($e->getPacket()) . " is not a " . BossEventPacket::class);
+		/** @var BossEventPacket $pk */
+		switch ($pk->eventType) {
+			case BossEventPacket::TYPE_REGISTER_PLAYER:
+			case BossEventPacket::TYPE_UNREGISTER_PLAYER:
+				Server::getInstance()->getLogger()->debug("Got BossEventPacket " . ($pk->eventType === BossEventPacket::TYPE_REGISTER_PLAYER ? "" : "un") . "register by client for player id " . $pk->playerActorUniqueId);
+				break;
+			default:
+				$e->getOrigin()->getPlayer()->kick("Invalid packet received", false);
+		}
+	}
 
 }


### PR DESCRIPTION
So users can now import the class 

use xenialdan\apibossbar\BarColor;

and use the method

$bar->setColor(BarColor::BLUE);  Blue for example.

to set the color without needing the use of the class BossBarColor cause some people might get confused and think that this plugin doesn’t support boss bar colors. I tested it on my server and came back positive with no errors!

This library was outdated so I updated the fork before submitting a request so the changes mentioning colors is the one I modified. Thank you 😊 

