### PR TITLE
fix: Uninitialized Variable Error static::$registrant

### DIFF
--- a/src/xenialdan/apibossbar/PacketListener.php
+++ b/src/xenialdan/apibossbar/PacketListener.php
@@ -11,7 +11,7 @@ use pocketmine\Server;
 
 class PacketListener implements Listener
 {
-	private static ?Plugin $registrant;
+	private static ?Plugin $registrant = null;
 
 	public static function isRegistered(): bool
 	{


### PR DESCRIPTION
**Problem** : crashed when call ```API::load(Plugin);```

PMMP Version : Latest (v5.15.0)
OS : Windows 11

Error Trace:

```PocketMine-MP Crash Dump Mon May 20 11:48:53 UTC 2024

PocketMine-MP version: 5.15.0 [Protocol 671]
Git commit: d273ccf87ca2e7ac52b4c6091576336930720edc
PHP version: 8.2.17
OS: WINNT, win

THIS CRASH WAS CAUSED BY A PLUGIN
BAD PLUGIN: BossBar

Thread: Main
Error: Typed static property xenialdan\apibossbar\PacketListener::$registrant must not be accessed before initialization
File: plugins/BossBar/src/xenialdan/apibossbar/PacketListener
Line: 18
Type: Error
Backtrace:
#0 plugins/BossBar/src/xenialdan/apibossbar/PacketListener(33): xenialdan\apibossbar\PacketListener::isRegistered()
#1 plugins/BossBar/src/xenialdan/apibossbar/API(17): xenialdan\apibossbar\PacketListener::register(object nicholass003\bossbar\Main#45290)
#2 plugins/BossBar/src/nicholass003/bossbar/Main(18): xenialdan\apibossbar\API::load(object nicholass003\bossbar\Main#45290)
#3 pmsrc/src/plugin/PluginBase(119): nicholass003\bossbar\Main->onEnable()
#4 pmsrc/src/plugin/PluginManager(454): pocketmine\plugin\PluginBase->onEnableStateChange(true)
#5 pmsrc/src/Server(1404): pocketmine\plugin\PluginManager->enablePlugin(object nicholass003\bossbar\Main#45290)
#6 pmsrc/src/Server(1035): pocketmine\Server->enablePlugins(object pocketmine\plugin\PluginEnableOrder#45242)
#7 pmsrc/src/PocketMine(355): pocketmine\Server->__construct(object pocketmine\thread\ThreadSafeClassLoader#6, object pocketmine\utils\MainLogger#2, string[38] D:\DevPMMP\ServerHalluxCraft\Practice\, string[46] D:\DevPMMP\ServerHalluxCraft\Practice\plugins\)
#8 pmsrc/src/PocketMine(378): pocketmine\server()
#9 D:/DevPMMP/ServerHalluxCraft/Practice/PocketMine-MP.phar(168): require(string[101] phar://C:/Users/ACER/AppData/Local/Temp/PocketMine-MP-phar-cache.0/PMM1E18.tmp.t)

Code:
[9] use pocketmine\plugin\Plugin;
[10] use pocketmine\Server;
[11] 
[12] class PacketListener implements Listener
[13] {
[14] 	private static ?Plugin $registrant;
[15] 
[16] 	public static function isRegistered(): bool
[17] 	{
[18] 		return self::$registrant instanceof Plugin;
[19] 	}
[20] 
[21] 	public static function getRegistrant(): Plugin
[22] 	{
[23] 		return self::$registrant;
[24] 	}
[25] 
[26] 	public static function unregister(): void
[27] 	{
[28] 		self::$registrant = null;

Loaded plugins:
BossBar 1.0.0 by nicholass003 for API(s) 5.0.0```